### PR TITLE
use break instead of raise

### DIFF
--- a/Mockbox.py
+++ b/Mockbox.py
@@ -32,4 +32,4 @@ while True:
         time.sleep(1)
     except KeyboardInterrupt:
         print "Shutting down..."
-        raise
+        break


### PR DESCRIPTION
By breaking out of the loop program will terminate normally instead of
abnormal because of exception.
